### PR TITLE
Point to the updated version of test script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,6 @@ build:
 test-container: build _submission_write_perms
 	docker run \
 		${TTY_ARGS} \
-		--mount type=bind,source="$(shell pwd)"/runtime/run-tests.sh,target=/run-tests.sh,readonly \
 		--mount type=bind,source="$(shell pwd)"/runtime/tests,target=/tests,readonly \
 		${LOCAL_IMAGE} \
 		/bin/bash -c "conda run --no-capture-output -n condaenv pytest tests/test_packages.py"

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test-container: build _submission_write_perms
 		--mount type=bind,source="$(shell pwd)"/runtime/run-tests.sh,target=/run-tests.sh,readonly \
 		--mount type=bind,source="$(shell pwd)"/runtime/tests,target=/tests,readonly \
 		${LOCAL_IMAGE} \
-		/bin/bash -c "bash /run-tests.sh"
+		/bin/bash -c "conda run --no-capture-output -n condaenv pytest tests/test_packages.py"
 
 ## Start your locally built container and open a bash shell within the running container; same as submission setup except has network access
 interact-container: build _submission_write_perms

--- a/runtime/run-tests.sh
+++ b/runtime/run-tests.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e
-
-echo "Running Python tests"
-conda run -n py python tests/test_installs.py


### PR DESCRIPTION
@jayqi -- the `make test-container` command was pointing to an old version of the `test_packages.py` script (FKA `test_installs.py` executed by `run-tests.sh`). This uses the updated script and aligns with the testing in GH workflows.