### PR TITLE
Docker fixes and optimization

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -29,7 +29,9 @@ jobs:
             --build-arg CPU_OR_GPU=${{ matrix.proc }} \
             --tag ${{ secrets.REGISTRY_LOGIN_SERVER }}/$IMAGE:$SHA_TAG \
             --tag ${{ secrets.REGISTRY_LOGIN_SERVER }}/$IMAGE:$LATEST_TAG
-          echo "----------------"
+
+      - name: Check image size
+        run: |
           docker image list ${{ secrets.REGISTRY_LOGIN_SERVER }}/$IMAGE
 
       - name: Tests packages in container

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -29,6 +29,7 @@ jobs:
             --build-arg CPU_OR_GPU=${{ matrix.proc }} \
             --tag ${{ secrets.REGISTRY_LOGIN_SERVER }}/$IMAGE:$SHA_TAG \
             --tag ${{ secrets.REGISTRY_LOGIN_SERVER }}/$IMAGE:$LATEST_TAG
+          docker image list
 
       - name: Tests packages in container
         run: |

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -29,7 +29,8 @@ jobs:
             --build-arg CPU_OR_GPU=${{ matrix.proc }} \
             --tag ${{ secrets.REGISTRY_LOGIN_SERVER }}/$IMAGE:$SHA_TAG \
             --tag ${{ secrets.REGISTRY_LOGIN_SERVER }}/$IMAGE:$LATEST_TAG
-          docker image list
+          echo "----------------"
+          docker image list ${{ secrets.REGISTRY_LOGIN_SERVER }}/$IMAGE
 
       - name: Tests packages in container
         run: |

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -34,6 +34,7 @@ RUN echo "Creating ${RUNTIME_USER} user..." \
 # Install base packages
 ARG DEBIAN_FRONTEND=noninteractive
 COPY ./apt.txt /home/${RUNTIME_USER}
+RUN rm /etc/apt/sources.list.d/cuda.list && rm /etc/apt/sources.list.d/nvidia-ml.list
 RUN echo "Installing base packages..." \
     && apt-get update --fix-missing \
     && apt-get install -y apt-utils 2> /dev/null \

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -62,6 +62,7 @@ RUN echo "Installing Miniforge..." \
 COPY environment-${CPU_OR_GPU}.yml /home/${RUNTIME_USER}/environment.yml
 RUN mamba env create --name ${CONDA_ENV} -f /home/${RUNTIME_USER}/environment.yml  \
     && mamba clean -afy \
+    && conda run pip cache purge \
     && rm /home/${RUNTIME_USER}/environment.yml \
     && find ${CONDA_DIR} -follow -type f -name '*.a' -delete \
     && find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete \

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.0-base-ubuntu20.04
+FROM nvidia/cuda:11.0.3-base-ubuntu20.04
 # adapated from build file for pangeo images
 # https://github.com/pangeo-data/pangeo-docker-images
 

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -34,7 +34,7 @@ RUN echo "Creating ${RUNTIME_USER} user..." \
 # Install base packages
 ARG DEBIAN_FRONTEND=noninteractive
 COPY ./apt.txt /home/${RUNTIME_USER}
-RUN rm /etc/apt/sources.list.d/cuda.list && rm /etc/apt/sources.list.d/nvidia-ml.list
+RUN rm -f /etc/apt/sources.list.d/cuda.list && rm -f /etc/apt/sources.list.d/nvidia-ml.list
 RUN echo "Installing base packages..." \
     && apt-get update --fix-missing \
     && apt-get install -y apt-utils 2> /dev/null \


### PR DESCRIPTION
- Clears apt lists so that apt doesn't struggle to verify nvidia's server
- Update base image to `nvidia/cuda:11.0.3-base-ubuntu20.04`
- Add a workflow step to print out the image size
- Runs `pip cache purge`, which deletes ~200 MB of cache